### PR TITLE
Print the error backtrace more readably.

### DIFF
--- a/lib/omg_pull_request/test_runner.rb
+++ b/lib/omg_pull_request/test_runner.rb
@@ -43,7 +43,7 @@ module OmgPullRequest
           end
 
         rescue => ex
-          puts "An Error Occured: #{ex.inspect}\n#{ex.backtrace}"
+          puts "An Error Occurred: #{ex.inspect}\n#{ex.backtrace.join "\n"}"
         end
 
         return if daemonize == false


### PR DESCRIPTION
Currently, the error backtrace looks like this:

```
An Error Occured: #<Errno::ETIMEDOUT: Operation timed out - connect(2)>
["/Users/webdev/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/net/http.rb:877:in `initialize'", "/Users/webdev/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/net/http.rb:877:in `open'", "/Users/webdev/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/net/http.rb:877:in `block in connect'", ...
```

Kind of unreadable.
